### PR TITLE
Allow lossy jpeg transcode at all distances > 0

### DIFF
--- a/jxl.net/Encoder/Encoder.cs
+++ b/jxl.net/Encoder/Encoder.cs
@@ -292,7 +292,7 @@ namespace jxlNET.Encoder
 
                     try
                     {
-                        if (param.GetType() == typeof(Distance) && ((Distance)param).Value > 1.0) args.Append(" --lossless_jpeg=0");
+                        if (param.GetType() == typeof(Distance) && ((Distance)param).Value > 0) args.Append(" --lossless_jpeg=0");
                     }
                     catch (Exception ex)
                     { }


### PR DESCRIPTION
Hi, sorry for bothering you if you're no longer working on this--I know jxl isn't a particularly hot topic at the moment.

Found a possible bug here. Code was applying --lossless_jpeg=0 when distance was above 1, but any distance above 0 is considered lossy by cjxl, so there was a blindspot for any distances between 0 and 1.

It works in my testing, but I'm not sure whether there was a purpose behind the original use of 1.0 here.